### PR TITLE
add some interfaces

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,23 +1,44 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
-    // Standard release options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
+// Although this function looks imperative, note that its job is to
+// declaratively construct a build graph that will be executed by an external
+// runner.
+pub fn build(b: *std.Build) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
 
-    const lib = b.addStaticLibrary("math", "src/main.zig");
-    lib.setBuildMode(mode);
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
+    const optimize = b.standardOptimizeOption(.{});
+
+    const lib = b.addStaticLibrary(.{
+        .name = "zig-libs-for-my-own-usage",
+        // In this case the main source file is merely a path, however, in more
+        // complicated build scripts, this could be a generated file.
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // This declares intent for the library to be installed into the standard
+    // location when the user invokes the "install" step (the default step when
+    // running `zig build`).
     lib.install();
 
-    const main_tests = b.addTest("src/main.zig");
-    main_tests.setBuildMode(mode);
+    // Creates a step for unit testing.
+    const main_tests = b.addTest(.{
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build test`
+    // This will evaluate the `test` step rather than the default, which is "install".
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&main_tests.step);
-
-    const docs = b.addTest("src/main.zig");
-    docs.setBuildMode(mode);
-    docs.emit_docs = .emit;
-    const docs_step = b.step("docs", "Generate documentation");
-    docs_step.dependOn(&docs.step);
 }

--- a/src/containers/contains.zig
+++ b/src/containers/contains.zig
@@ -1,0 +1,3 @@
+const std = @import("std");
+const DataType = std.ArrayList(u8);
+

--- a/src/ecs/component.zig
+++ b/src/ecs/component.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+/// Component constructor
+/// create a normal zig struct using args
+/// and create it's storage using options
+/// leave options .{} for default options
+/// example:
+/// const Transform = Component(.{
+///     .x = 0.0,
+///     .y = 0.0,
+///     .z = 0.0
+/// }, .{});
+/// then you can just using this type as a component inside any system function
+pub fn Component(comptime args: anytype, comptime options: ComponentOptions) type {
+    // check the options and set up storage of this type
+    // check about the arguments for more details(component type arguments should all be ownned types or will cause memory leak)
+    // return the final component type
+}

--- a/src/ecs/ecs.zig
+++ b/src/ecs/ecs.zig
@@ -1,0 +1,3 @@
+pub const ecs = @This();
+const std = @import("std");
+const Component = @import("component.zig").Component;

--- a/src/gql/gql.zig
+++ b/src/gql/gql.zig
@@ -2,76 +2,93 @@ const gql = @This();
 const std = @import("std");
 const trait = std.meta.trait;
 pub const parser = @import("parser.zig");
-/// type checker for scalar type
-/// return false immediately when one item check is failed
-/// you can replace return false things to custom error to show more info
-/// every step of the type check having debug print
-/// you can remove it if you want to
-/// this is equal with the a trait in rust like:
-/// trait ScalarType<'a> {
-///     fn serialize(&mut self) -> &'a str;
-///     fn deserialize(input: &'a str') -> Self;
-/// }
-/// but a little more, because we expect type to having a type_name field
-/// which is a comptime []const u8
-/// notice: this type checker may not being used outside of this library
-/// scalar type is only need to check when default parse rule is failed
-pub fn isScalarType(comptime T: type) bool {
-    std.debug.print("\ntype check starting...\n", .{});
-    if (@typeInfo(T) != .Struct) {
-        return false;
-    }
-    std.debug.print("root type check passed...\n", .{});
-    if (!trait.hasFn("serialize")(T)) return false;
-    std.debug.print("serialize function is contained...\n", .{});
-    const serialize_fn = @typeInfo(@TypeOf(@field(T, "serialize"))).Fn;
-    const serialize_fn_args = serialize_fn.args;
-    if (serialize_fn_args.len != 1) {
-        return false;
-    }
-    std.debug.print("serialize function's args length is correct...\n", .{});
-    if (!trait.isPtrTo(@typeInfo(T))(serialize_fn_args[0].arg_type.?)) {
-        return false;
-    }
-    std.debug.print("serialize function's args type is correct...\n", .{});
-    if (serialize_fn.return_type != []const u8) {
-        return false;
-    }
-    std.debug.print("serialize function's return type is correct...\n", .{});
+// /// type checker for scalar type
+// /// return false immediately when one item check is failed
+// /// you can replace return false things to custom error to show more info
+// /// every step of the type check having debug print
+// /// you can remove it if you want to
+// /// this is equal with the a trait in rust like:
+// /// trait ScalarType<'a> {
+// ///     fn serialize(&mut self) -> &'a str;
+// ///     fn deserialize(input: &'a str') -> Self;
+// /// }
+// /// but a little more, because we expect type to having a type_name field
+// /// which is a comptime []const u8
+// /// notice: this type checker may not being used outside of this library
+// /// scalar type is only need to check when default parse rule is failed
+// pub fn isScalarType(comptime T: type) bool {
+//     std.debug.print("\ntype check starting...\n", .{});
+//     if (@typeInfo(T) != .Struct) {
+//         return false;
+//     }
+//     std.debug.print("root type check passed...\n", .{});
+//     if (!trait.hasFn("serialize")(T)) return false;
+//     std.debug.print("serialize function is contained...\n", .{});
+//     const serialize_fn = @typeInfo(@TypeOf(@field(T, "serialize"))).Fn;
+//     const serialize_fn_args = serialize_fn.params;
+//     if (serialize_fn_args.len != 1) {
+//         return false;
+//     }
+//     std.debug.print("serialize function's args length is correct...\n", .{});
+//     if (!trait.isPtrTo(@typeInfo(T))(serialize_fn_args[0].type.?)) {
+//         return false;
+//     }
+//     std.debug.print("serialize function's args type is correct...\n", .{});
+//     if (serialize_fn.return_type != []const u8) {
+//         return false;
+//     }
+//     std.debug.print("serialize function's return type is correct...\n", .{});
 
-    if (!trait.hasFn("deserialize")(T)) return false;
-    std.debug.print("deserialize function si contained...\n", .{});
+//     if (!trait.hasFn("deserialize")(T)) return false;
+//     std.debug.print("deserialize function si contained...\n", .{});
 
-    const deserialize_fn = @typeInfo(@TypeOf(@field(T, "deserialize"))).Fn;
-    const deserialize_fn_args = deserialize_fn.args;
-    if (deserialize_fn_args.len != 1) {
-        return false;
-    }
-    std.debug.print("deserialize function's args length is correct\n", .{});
-    if (deserialize_fn_args[0].arg_type.? != []const u8) {
-        return false;
-    }
-    std.debug.print("deserialize function's args type is correct...\n", .{});
-    if (deserialize_fn.return_type != T) {
-        return false;
-    }
-    std.debug.print("deserialize function's return type is correct...\n", .{});
-    if (@hasField(T, "type_name")) {
-        std.debug.print("type_name arg is contained...\n", .{});
-        inline for (@typeInfo(T).Struct.fields) |field| {
-            comptime if (std.mem.indexOfDiff(u8, field.name, "type_name")) |index_diff| {
-                _ = index_diff;
-                continue;
-            };
-            if (field.field_type != []const u8) {
-                return false;
-            }
-            std.debug.print("type_name arg's type is correct...\n", .{});
-            if (!field.is_comptime) {
-                return false;
-            }
-            std.debug.print("type_name arg is comptime...\n", .{});
-        }
-    }
-    return true;
-}
+//     const deserialize_fn = @typeInfo(@TypeOf(@field(T, "deserialize"))).Fn;
+//     const deserialize_fn_args = deserialize_fn.params;
+//     if (deserialize_fn_args.len != 1) {
+//         return false;
+//     }
+//     std.debug.print("deserialize function's args length is correct\n", .{});
+//     if (deserialize_fn_args[0].type.? != []const u8) {
+//         return false;
+//     }
+//     std.debug.print("deserialize function's args type is correct...\n", .{});
+//     if (deserialize_fn.return_type != T) {
+//         return false;
+//     }
+//     std.debug.print("deserialize function's return type is correct...\n", .{});
+//     if (@hasField(T, "type_name")) {
+//         std.debug.print("type_name arg is contained...\n", .{});
+//         inline for (@typeInfo(T).Struct.fields) |field| {
+//             comptime if (std.mem.indexOfDiff(u8, field.name, "type_name")) |index_diff| {
+//                 _ = index_diff;
+//                 continue;
+//             };
+//             if (field.type != []const u8) {
+//                 return false;
+//             }
+//             std.debug.print("type_name arg's type is correct...\n", .{});
+//             if (!field.is_comptime) {
+//                 return false;
+//             }
+//             std.debug.print("type_name arg is comptime...\n", .{});
+//         }
+//     }
+//     return true;
+// }
+// test "scalar" {
+//     const A = struct {
+//         // const json = std.json;
+//         const Self = @This();
+//         comptime type_name: []const u8 = "Null",
+//         pub fn serialize(self: *Self) []const u8 {
+//             _ = self;
+//             return "null";
+//         }
+//         pub fn deserialize(input: []const u8) Self {
+//             _ = input;
+//             return Self{};
+//         }
+//     };
+//     try std.testing.expect(gql.isScalarType(A));
+// }
+// those things are not friendly for building high-level api

--- a/src/gql/parser.zig
+++ b/src/gql/parser.zig
@@ -1,158 +1,99 @@
-// //! gql parser aims to parse zig code to schema string
-// //! and parse query string to zig variables
-// //! cause that Query Mutation and Subscription are also schema objects
-// //! this will works for them too
-// const gql = @import("gql.zig");
-// const std = @import("std");
-// const parser = @This();
-
-// /// zig tyoe to graphql type definitions
-// /// output type is auto-detected
-// /// like struct will become object
-// /// union will become union
-// /// enum will become enum
-// /// scalar type will become scalar type
-// pub fn zigTypeToGraphqlType(comptime T: type, comptime subTypeOfOptional: bool) []const u8 {
-//     const typeInfo = @typeInfo(T);
-//     if (gql.isScalarType(T)) return res: {
-//         if (subTypeOfOptional) break :res T.type_name;
-//         break :res T.type_name ++ "!";
-//     };
-
-//     switch (typeInfo) {
-//         .Type, .Void, .NoReturn => {
-//             @compileError("not supported type to parse");
-//         },
-//         .ComptimeFloat, .ComptimeInt => {
-//             @compileError(
-//                 \\ compile time value is not able to deserialize from runtime.
-//                 \\ using the same type runtime value instead
-//             );
-//         },
-//         .Undefined, .Null => {
-//             @compileError(
-//                 \\ undefined and null value is not supported in the graphql side
-//                 \\ if you really need some type to describe for no return from the api
-//                 \\ try to declare a scalar type about it
-//             );
-//         },
-//         .Vector => {
-//             @compileError(
-//                 \\ Vector type is not supported in the current version of this project
-//                 \\ also Vector type in zig is not the same as vecoter type in c++ std lib or rust's Vec type
-//                 \\ it is static sized simd vector, try arraylist if you want some dynamic size array
-//             );
-//         },
-//         .Frame, .AnyFrame => {
-//             @compileError(
-//                 \\ frame type are not some thing that could be parsed to gql type
-//                 \\ and you don't have to
-//             );
-//         },
-//         .Opaque => {
-//             @compileError(
-//                 \\ opaque type are not actually zig type
-//                 \\ try to implemente a scalar type for it
-//                 \\ if you want to parse it
-//             );
-//         },
-//         .EnumLiteral => {
-//             @compileError(
-//                 \\ using enum or union instead
-//             );
-//         },
-//         .Bool => {
-//             return res: {
-//                 if (subTypeOfOptional) break :res "Boolean";
-//                 break :res "Boolean!";
-//             };
-//         },
-//         .Int => {
-//             // will become graphql's int type
-//             // that is why I ignore the value of this type here
-//             return res: {
-//                 if (subTypeOfOptional) break :res "Int";
-//                 break :res "Int!";
-//             };
-//         },
-//         .Float => {
-//             // same reason as above
-//             return res: {
-//                 if (subTypeOfOptional) break :res "Float";
-//                 break :res "Float!";
-//             };
-//         },
-//         .Pointer => |p| {
-//             return parsePointerType(p);
-//         },
-//         .Array => |array| {
-//             // a lot people don't know but there actually is a type like this [A!]!
-//             return res: {
-//                 if (subTypeOfOptional) break :res "[" ++ zigTypeToGraphqlType(array.child, false) ++ "]";
-//                 break :res "[" ++ zigTypeToGraphqlType(array.child) ++ "]!";
-//             };
-//         },
-//         .Struct => |obj| {
-//             comptime var res = "type " ++ @typeName(obj) ++ " {";
-//             for (obj.fields) |field| {
-//                 res = res ++ "\t\t" + field.name + ": " + zigTypeToGraphqlType(field.field_type, false) ++ "\n";
-//             }
-//             res = res ++ "}";
-//             return res;
-//         },
-//         .Optional => |op| {
-//             return zigTypeToGraphqlType(op.child);
-//         },
-//         // ErrorUnion: ErrorUnion,
-//         // ErrorSet: ErrorSet,
-//         // Enum: Enum,
-//         // Union: Union,
-//         // Fn: Fn,
-//         // BoundFn: Fn,
+//! gql parser aims to parse zig code to schema string
+//! and parse query string to zig variables
+//! experimental right now
+const gql = @import("gql.zig");
+const std = @import("std");
+const parser = @This();
+pub const ParseContext = enum {
+    IsInnerTypeOfType,
+    IsInnerTypeOfPointer,
+    IsInnerTypeOfPointerAndType,
+    const Self = @This();
+    pub fn join(self: *Self, rhs: *Self) !Self {
+        return switch (self) {
+            .IsInnerTypeOfType => {
+                switch (rhs) {
+                    .IsInnerTypeOfType => .IsInnerTypeOfType,
+                    .IsInnerTypeOfPointer => .IsInnerTypeOfPointerAndType,
+                    .IsInnerTypeOfPointerAndType => .IsInnerTypeOfPointerAndType,
+                }
+            },
+            .IsInnerTypeOfPointer => {
+                switch (rhs) {
+                    .IsInnerTypeOfType => .IsInnerTypeOfPointerAndType,
+                    .IsInnerTypeOfPointer => .IsInnerTypeOfPointer,
+                    .IsInnerTypeOfPointerAndType => .IsInnerTypeOfPointerAndType,
+                }
+            },
+            .IsInnerTypeOfPointerAndType => .IsInnerTypeOfPointerAndType,
+        };
+    }
+};
+// /// output type should be type xxxx {}
+// pub fn gqlParseType(comptime T: type, comptime ctx: ?ParseContext) []const u8 {}
+// /// will parse the type behind the pointer
+// pub fn gqlParsePointType(comptime T: type, comptime ctx: ?ParseContext) []const u8 {}
+// /// output type should be interface xxxx {}
+// pub fn gqlParseInterface(comptime T: type, comptime ctx: ?ParseContext) []const u8 {}
+// /// output type should be union = xxx | xxx
+// pub fn gqlParseUnion(comptime T: type, comptime ctx: ?ParseContext) []const u8 {
+//     if (ctx == null) {
+//         var res = "union ";
+//         res += @typeName(T);
+//         res += "=";
+//         const typeInfo = @typeInfo(T);
+//         switch (typeInfo) {
+//             .Union => |u|{
+//                 for (u.fields) |field| {
+//                     switch (@typeInfo(field.field_type)) {
+//                         .Struct, .Union, .Enum, .Int, .Float, .ComptimeFloat, .ComptimeInt => {
+//                             res += " " + field.name;
+//                         },
+//                         .Pointer => |p| {
+//                             if (T == []const u8) {
+//                                 res += " String";
+//                             } else {
+//                                 if (p.size != .One) {
+//                                     @compileError("array is not supported in graphql union");
+//                                 }
+//                                 res += gqlParsePointType(@Type(p), .IsInnerTypeOfType);
+//                             }
+//                         },
+//                         else => {
+//                             comptimeError("not supported field type for graphql union");
+//                         },
+//                     }
+//                     res += field.name + "\n";
+//                 }
+//                 res += "}";
+//             },
+//             else => @compileError("only allow union right here"),
+//         }
+//         return res;
+//     } else {
+//         return @typeName(T);
 //     }
 // }
-
-// /// parse one field of enum struct or union
-// fn parseFieldOfAComplexType(comptime T: type, comptime isSubtype: bool) []const u8 {
-//     if (isSubtype) return @typeName(T);
-
-//     const typeInfo = @typeInfo(T);
-//     switch (typeInfo) {
-//         .Int, .Float, .Bool => {
-//             return zigTypeToGraphqlType(T, false);
-//         },
-//         .Pointer => |p| {
-//             if (T == []const u8) return res: {
-//                 if (subTypeOfOptional) break :res "String";
-//                 break :res "String!";
-//             };
-//             return parsePointerType(p.child);
-//         },
+// /// output type should be enum xxx {}
+// pub fn gqlParseEnum(comptime T: type, comptime ctx: ?ParseContext) []const u8 {
+//     if (ctx == null) {
+//         var res = "enum ";
+//         res += @typeName(T);
+//         res += "{\n";
+//         const typeInfo = @typeInfo(T);
+//         switch (typeInfo) {
+//             .Enum => |e| {
+//                 for (e.fields) |field| {
+//                     res += field.name + "\n";
+//                 }
+//                 res += "}";
+//             },
+//             else => @compleError("only allow enum right here"),
+//         }
+//         return res;
+//     } else {
+//         return @typeName(T);
 //     }
 // }
-
-// fn parsePointerType(comptime ptr: std.builtin.Type.Pointer) []const u8 {
-//     if (ptr.size != .One) {
-//         // for string types
-//         if (ptr.child == u8) return res: {
-//             if (subTypeOfOptional) break :res "String";
-//             break :res "String!";
-//         };
-//         @compileError(
-//             \\ array pointer or slice is only supported for u8
-//             \\ because of zig's string implementation
-//             \\ try arraylist type from the standard library
-//             \\ if you need a unknown size container of something
-//         );
-//     }
-//     switch (@typeInfo(ptr.child)) {
-//         .Struct, .Union => {
-//             return zigTypeToGraphqlType(ptr.child, false);
-//         },
-//         else => {
-//             @compileError(
-//                 \\ only support struct or union pointer here
-//             );
-//         },
-//     }
-// }
+// /// zig's builtin type to gql type
+// pub fn gqlParseSimpleBuiltInType(comptime T: type, comptime ctx: ?ParseContext) []const u8 {}

--- a/src/utils/comparable.zig
+++ b/src/utils/comparable.zig
@@ -1,0 +1,139 @@
+//! comparable type trait
+const std = @import("std");
+const StringHashMap = std.hash_map.StringHashMap;
+
+/// enum for comparing results
+pub const CompareResult = enum(u8) {
+    Greater = 0,
+    Equal = 1,
+    Less = 2,
+};
+fn ComparableMethodsRule(comptime T: type) fn (?type) type {
+    return struct {
+        pub fn function(comptime RHS: ?type) type {
+            return comptime struct {
+                const Self = @This();
+                const Target = rhs: {
+                    if (RHS) |R| {
+                        break :rhs R;
+                    }
+                    break :rhs T;
+                };
+                comptime RHS: type = Target,
+                cmpFn: *const fn (T, Target) CompareResult,
+            };
+        }
+    }.function;
+}
+fn InterfaceTypeInfer(comptime Impl: type, comptime RHS: ?type) fn (comptime ComparableMethodsRule(Impl)(RHS)) type {
+    return struct {
+        pub fn run(comptime rules: ComparableMethodsRule(Impl)(RHS)) type {
+            return struct {
+                impl: Impl,
+                const Self = @This();
+                pub inline fn cmp(self: Self, rhs: rules.RHS) CompareResult {
+                    return rules.cmpFn(self.impl, rhs);
+                }
+            };
+        }
+    }.run;
+}
+
+/// basic comparable trait
+/// the cmp is the only required method
+/// more methods coming soon
+pub fn Comparable(comptime Impl: type) type {
+    return struct {
+        pub fn impl(comptime RHS: ?type) fn (comptime ComparableMethodsRule(Impl)(RHS)) type {
+            return struct {
+                pub fn function(comptime rules: ComparableMethodsRule(Impl)(RHS)) fn (Impl) InterfaceTypeInfer(Impl, RHS)(rules) {
+                    return struct {
+                        pub fn run(impl_: Impl) InterfaceTypeInfer(Impl, RHS)(rules) {
+                            return .{
+                                .impl = impl_,
+                            };
+                        }
+                    }.run;
+                }
+            }.function;
+        }
+    };
+}
+
+pub fn isComparableTo(comptime T: type) fn (type) bool {
+    return struct {
+        pub fn fun(subtype: type) bool {
+            const compareFunctionName = if(T == subtype) {
+                "cmpSelf";
+            } else {
+                "cmp" ++ @typeName(subtype);
+            };
+            const trait = std.meta.trait;
+            // const Type = std.builtin.Type;
+            if(!trait.hasFn(compareFunctionName)) return false;
+            const typeInfo = @typeInfo(T);
+            if(typeInfo != .Struct) {
+                return false;
+            }
+            const typeStructInfo = typeInfo.Struct;
+            for(typeStructInfo.fields) |field| {
+                if(field.type == InterfaceTypeInfer(T, subtype)) return true;
+            }
+            return false;
+        }
+    }.fun;
+}
+// something I wish will work in the future version of zig
+// pub fn ComparableManager(comptime Impl: type) type {
+//     return struct {
+//         map: StringHashMap(*const anyopaque) = StringHashMap(*const anyopaque).init(std.heap.page_allocator),
+//         const Self = @This();
+//         const TypeArgs = struct {
+//             comptime RHS: ?type = null,
+//         };
+
+//         const Result = struct {
+//             map: StringHashMap(*anyopaque),
+//             pub fn cmp(self: @This(), comptime RHS: type) fn (Impl, RHS) CompareResult {
+//                 if (self.map.get(@typeName(RHS)) == null) {
+//                     @compileError("the trait Comparable(RHS: " ++ @typeName(RHS) ++ ") is not satisfied, do you have the implementation for that type?");
+//                 }
+//                 return @ptrCast(*const fn (Impl, RHS) CompareResult, self.map.get(@typeName(RHS)));
+//             }
+//         };
+//         pub fn init() Self {
+//             comptime {
+//                 return Self{};
+//             }
+//         }
+//         fn MethodBuilder(comptime type_args: TypeArgs, comptime self: Self) fn (comptime ComparableMethodsRule(Impl)(type_args.RHS)) Self {
+//             // generate method types using type arguments that input
+//             // return those methods with a struct with the impl function
+//             return struct {
+//                 pub fn impl(comptime rules: ComparableMethodsRule(Impl)(type_args.RHS)) Self {
+//                     comptime {
+//                         var map = try self.map.clone();
+//                         try map.put(typename: {
+//                             if (type_args.RHS) |some| {
+//                                 break :typename @typeName(some);
+//                             }
+//                             break :typename @typeName(Impl);
+//                         }, @ptrCast(*const anyopaque, &rules.cmpFn));
+//                         self.map.deinit();
+//                         self.map = map;
+//                         return self;
+//                     }
+//                 }
+//             }.impl;
+//         }
+//         pub fn where(comptime self: Self, comptime type_args: TypeArgs) fn (comptime ComparableMethodsRule(Impl)(type_args.RHS)) Self {
+//             // return a MethodBuilder
+//             return MethodBuilder(type_args, self);
+//         }
+//         pub fn end(comptime self: *Self) Result {
+//             return Result{
+//                 .map = self.map,
+//             };
+//         }
+//     };
+// }

--- a/src/utils/iter.zig
+++ b/src/utils/iter.zig
@@ -1,66 +1,24 @@
 //! iterator trait and some specific methods
 const std = @import("std");
-/// check if the iter type is an iterator over type inner
-pub fn isIteratorOf(comptime iter: type, comptime inner: type) bool {
-    // iterator should be a struct type
-    if (@typeInfo(iter) != .Struct) return false;
-    // should have a next() method
-    if (!comptime @hasDecl(iter, "next")) return false;
-    const next_fn_info = @typeInfo(@TypeOf(@field(iter, "next")));
-    if (next_fn_info != .Fn) return false;
-    const return_type = next_fn_info.Fn.return_type;
-    // next() should return an optional of type inner
-    if (return_type.? != ?inner) return false;
-    return true;
-}
-/// an empty iterator implementation
-/// will always return null
-pub fn EmptyIter(comptime T: type) type {
+/// basic iterator trait
+/// the next is the only required method
+/// more methods coming soon
+pub fn Iterator(comptime Impl: type, comptime Value: type, comptime methods: struct {
+    next: *const fn (Impl) ?Value,
+}) type {
     return struct {
-        pub fn next() ?T {
-            return null;
+        pub const @"utils.Iterator" = struct {
+            impl: Impl,
+            const Self = @This();
+            pub const Item = Value;
+            pub inline fn next(self: Self) ?Item {
+                return methods.next(self.impl);
+            }
+        };
+        pub fn iterator(self: Impl) @"utils.Iterator" {
+            return .{
+                .impl = self,
+            };
         }
     };
-}
-
-const testing = std.testing;
-test "iter" {
-    const EmptyIterI32 = EmptyIter(i32);
-    try testing.expect(isIteratorOf(EmptyIterI32, i32));
-}
-
-/// check if the type could be iterate
-/// inner type represents the iterator's inner type
-pub fn isIterable(comptime target: type, comptime inner: type) bool {
-    // need to be struct type to have function field
-    if (@typeInfo(target) != .Struct) return false;
-    if (!comptime @hasDecl(target, "iter")) return false;
-    const iter_fn_info = @typeInfo(@TypeOf(@field(target, "iter")));
-    if (iter_fn_info != .Fn) return false;
-    const iter_return_type = iter_fn_info.Fn.return_type;
-    // iter function should return a iterator that will pass the isIteratorOf trait
-    if (isIteratorOf(iter_return_type.?, ?*const inner)) return false;
-    if (!comptime @hasDecl(target, "iter_mut")) return false;
-    const iter_mut_fn_info = @typeInfo(@TypeOf(@field(target, "iter_mut")));
-    if (iter_mut_fn_info != .Fn) return false;
-    const iter_mut_return_type = iter_mut_fn_info.Fn.return_type;
-    // iter function should return a iterator that will pass the isIteratorOf trait
-    if (isIteratorOf(iter_mut_return_type.?, ?*inner)) return false;
-    return true;
-}
-
-pub fn EmptyIterable(comptime T: type) type {
-    return struct {
-        pub fn iter() EmptyIter(*const T) {
-            return EmptyIter(*const T){};
-        }
-        pub fn iter_mut() EmptyIter(*T) {
-            return EmptyIter(*T){};
-        }
-    };
-}
-
-test "iterable" {
-    const EIi32 = EmptyIterable(i32);
-    try testing.expect(isIterable(EIi32, i32));
 }

--- a/src/utils/owned_optional_type.zig
+++ b/src/utils/owned_optional_type.zig
@@ -1,0 +1,298 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const testing = std.testing;
+const meta = std.meta;
+const builtin = std.builtin;
+const Comparable = @import("comparable.zig");
+const utils = @import("utils.zig");
+const option = @This();
+/// some type that is a liite bit like rust's optional type
+/// I do this just to get rid of if(something != null)
+/// and don't want to see some error messages like
+/// xxx type not supported member access because it is a optional
+/// sometime I just want to .expect("get a null xxx");
+/// if you like to handle null by you self
+/// and you know every optional value's ownership
+/// you can skip this type and use the zig original optional type
+/// this type is experimental and may contains some bugs
+/// help me to make it better!
+/// not having unwrap_unchecked
+/// just because every unwrap operations here are unchecked
+/// no as_pin_ref or as_pin_mut
+/// cause zig's async runtime is not the same
+/// no ok_or or ok_or_else or some other thing to converts to Result type
+/// not checked with union types, hope it will works
+/// this type is implemented the Comparable trait in the same folder
+pub fn Option(comptime T: type) type {
+    return struct {
+        /// for hidding memory operations
+        /// I specified the allocator for this type
+        /// in future versions I will implement a general one for this type
+        const allocator: Allocator = std.heap.page_allocator;
+        const Self = @This();
+        const ComparedResult = Comparable.ComparedResult;
+        /// it just wrapping around a optional type
+        /// but this memory's ownership is holded by the type
+        value: ?*T,
+        /// zig's error handling is different
+        /// so I put the errors here
+        /// also as you can see
+        /// because of this kind of error handling
+        /// Result type could not be implemented here
+        pub const Error = error{
+            UnhandledNullValue,
+            MappingWithInvalidFunctionOrNotFunction,
+        };
+        /// exactly works the same as the outside one
+        pub fn Some(value: T) !Option(T) {
+            var ptr = try Self.allocator.create(T);
+            ptr.* = value;
+            return Self{ .value = ptr };
+        }
+        /// the none value
+        /// just a ownership upon null value
+        /// may be in future we will have zero bit None
+        pub const None = Self{ .value = null };
+        /// Returns true if the option is a Some value.
+        pub fn is_some(self: *const Self) bool {
+            return !self.is_none();
+        }
+        /// Returns true if the option is a None value.
+        pub fn is_none(self: *const Self) bool {
+            return self.value == null;
+        }
+        /// Returns true if the option is a Some value containing the given value.
+        pub fn contains(self: *Self, x: *T) bool {
+            if (self.is_none()) return false;
+            return self.value.?.* == x.*;
+        }
+        /// this gives only const pointer
+        /// exactly like the borrow in rust
+        pub fn as_ref(self: *const Self) !Option(*const T) {
+            if (self.is_none()) return Option(*const T).None;
+            return try Option(*const T).Some(self.value.?);
+        }
+        /// this will give the mutiable pointer to inner value
+        /// but because zig does not check multithread safety
+        /// this may not works the same as rust's
+        pub fn as_mut(self: *Self) !Option(*T) {
+            if (self.is_none()) return Option(*T).None;
+            return try Option(*T).Some(self.value.?);
+        }
+
+        /// Returns the contained Some value, consuming the self value.
+        /// PS: this will drop the inner value's memory address
+        /// any optional around this type may cause undefined behavior
+        pub fn expect(self: *Self, msg: anyerror) !T {
+            if (self.is_none()) return msg;
+            var res = self.value.?.*;
+            self.deinit();
+            return res;
+        }
+        /// Returns the contained Some value, consuming the self value.
+        /// Because this function may panic, its use is generally discouraged.
+        /// Instead, prefer to use pattern matching and handle the None case explicitly,
+        /// or call unwrap_or, unwrap_or_else, or unwrap_or_default.
+        /// PS: this will drop the inner value's memory address
+        /// any optional around this type may cause undefined behavior
+        pub fn unwrap(self: *Self) !T {
+            return self.expect(Self.Error.UnhandledNullValue);
+        }
+        /// Returns the contained Some value or a provided default.
+        /// Arguments passed to unwrap_or are eagerly evaluated;
+        /// if you are passing the result of a function call,
+        /// it is recommended to use unwrap_or_else, which is lazily evaluated.
+        /// PS: this will drop the inner value's memory address
+        /// any optional around this type may cause undefined behavior
+        pub fn unwrap_or(self: *Self, default: T) T {
+            if (self.is_none()) return default;
+            var res = self.value.?.*;
+            self.deinit();
+            return res;
+        }
+        /// Returns the contained Some value or computes it from a function.
+        /// zig not having closure right now, but we can use function pointer
+        /// it should works the same but just a little waste of memory
+        /// PS: this will drop the inner value's memory address
+        /// any optional around this type may cause undefined behavior
+        pub fn unwrap_or_else(self: *Self, f: *const fn () T) T {
+            if (self.is_none()) return f();
+            var res = self.value.?.*;
+            self.deinit();
+            return res;
+        }
+
+        /// Maps an Option<T> to Option<U> by applying a function to a contained value.
+        /// this really takes a litte bit time to found implementation for this
+        /// it may not looks like a right implementation
+        /// but it works kind well
+        /// this operation will not change anything inside this type
+        /// the function gives here also not have the chance to change the inner value
+        /// even when it can, the value it got is a temporary value
+        pub fn map(self: *Self, f: anytype) !Option(@typeInfo(@TypeOf(f)).Fn.return_type.?) {
+            if (@typeInfo(@TypeOf(f)).Fn.params.len == 1) {
+                if (self.is_none()) return Self.Error.UnhandledNullValue;
+                var value_cloned = try Self.allocator.create(T);
+                value_cloned.* = self.value.?.*;
+                var output = f(value_cloned.*);
+                var res = try Option(@TypeOf(output)).Some(output);
+                Self.allocator.destroy(value_cloned);
+                return res;
+            } else {
+                return Self.Error.MappingWithInvalidFunctionOrNotFunction;
+            }
+        }
+        /// Returns the provided default result (if none),
+        /// or applies a function to the contained value (if any).
+        /// Arguments passed to map_or are eagerly evaluated;
+        /// if you are passing the result of a function call,
+        /// it is recommended to use map_or_else, which is lazily evaluated.
+        /// same rule as the map one
+        pub fn map_or(self: *Self, f: anytype, default: @typeInfo(@TypeOf(f)).Fn.return_type.?) !@typeInfo(@TypeOf(f)).Fn.return_type.? {
+            if (self.is_none()) return default;
+            var map_result = try self.map(f);
+            return map_result.unwrap();
+        }
+        /// Computes a default function result (if none),
+        /// or applies a different function to the contained value (if any).
+        /// also the same rule as the map one
+        pub fn map_or_else(self: *Self, f: anytype, default: fn () @typeInfo(@TypeOf(f)).Fn.return_type.?) !@typeInfo(@TypeOf(f)).Fn.return_type.? {
+            if (self.is_none()) return default();
+            var map_result = try self.map(f);
+            return map_result.unwrap();
+        }
+        /// zig not having auto drop
+        /// so we need to drop it ourselves
+        pub fn deinit(self: *Self) void {
+            if (self.is_some()) Self.allocator.destroy(self.value.?);
+            self.value = null;
+        }
+        pub const ComparableSelf = utils.Comparable(*Self).impl(null)(.{
+            .cmpFn = cmp,
+        });
+        /// try to implement a comparable for Option type
+        /// inner type is must be comparable or implement Comparable
+        pub fn cmp(self: *Self, other: Self) utils.CompareResult {
+            if (self.is_none()) {
+                if(other.is_none()) {
+                    return .Equal;
+                } else {
+                    return .Less;
+                }
+            }
+
+            var value = self.value.?.*;
+            var othervalue = other.value.?.*;
+            switch (@typeInfo(@TypeOf(value))) {
+                .Float, .Int => {
+                    if (value == othervalue) return utils.CompareResult.Equal;
+                    if (value < othervalue) return utils.CompareResult.Less;
+                    if (value > othervalue) return utils.CompareResult.Greater;
+                },
+                .Struct => {
+                    if (utils.isComparableTo(Self)(Self)) {
+                        return value.cmp(othervalue);
+                    } else {
+                        @compileError("struct type " ++ @TypeOf(value) ++ "is not implemented comparable",);
+                    }
+                },
+                .Pointer => {
+                    var res = std.cstr.cmp(value, othervalue);
+                    if (res == 0) return Self.ComparedResult.Equal;
+                    if (res == 1) return Self.ComparedResult.Greater;
+                    if (res == -1) return Self.ComparedResult.Less;
+                },
+                else => {
+                    @compileError("type " ++ @typeInfo(@TypeOf(value)) ++ " are not comparable");
+                },
+            }
+            // will Become Error in the future
+            return Self.ComparedResult.NotComparable;
+        }
+        // don't trying this, the ownership will be broken
+        // pub fn from(optional: ?*T) Self {
+        //     return Self{ .value = optional };
+        // }
+    };
+}
+const OptionI32 = Option(i32);
+
+test "Some and None" {
+    var i: i32 = 2;
+    var a = try OptionI32.Some(i);
+    a.deinit();
+    a = OptionI32.None;
+}
+test "is_some and is_none" {
+    var i: i32 = 2;
+    var a = try OptionI32.Some(i);
+    try testing.expect(a.is_some());
+    a.deinit();
+    a = OptionI32.None;
+    try testing.expect(a.is_none());
+}
+test "contains" {
+    var i: i32 = 2;
+    var j: i32 = 2;
+    var a = try OptionI32.Some(i);
+    try testing.expect(a.contains(&j));
+    a.deinit();
+    a = OptionI32.None;
+    try testing.expect(!a.contains(&j));
+}
+
+test "as_ref" {
+    var i: i32 = 2;
+    var a = try OptionI32.Some(i);
+    defer a.deinit();
+    var a_ref = try a.as_ref();
+    var b = try a_ref.unwrap();
+    try testing.expect(b.* == 2);
+}
+
+test "as_mut" {
+    var i: i32 = 2;
+    var a = try OptionI32.Some(i);
+    defer a.deinit();
+    var a_mut_ref = try a.as_mut();
+    var b = try a_mut_ref.unwrap();
+    b.* = 3;
+    var a_ref = try a.as_ref();
+    var c = try a_ref.unwrap();
+    try testing.expect(c.* == 3);
+}
+fn ff() *const i32 {
+    var res: i32 = 2;
+    return &res;
+}
+test "unwraps" {
+    var i: i32 = 2;
+    var a = OptionI32.None;
+    defer a.deinit();
+    var a_ref = try a.as_ref();
+    var b = a_ref.unwrap_or(&i);
+    try testing.expect(b.* == i);
+    a_ref = try a.as_ref();
+    var c = a_ref.unwrap_or_else(ff);
+    try testing.expect(c.* == 2);
+}
+fn defaultF() i32 {
+    var res: i32 = 2;
+    return res;
+}
+fn mapping(input: i32) i32 {
+    return input + 1;
+}
+test "maps" {
+    var i: i32 = 2;
+    var a = try OptionI32.Some(i);
+    var b = try a.map(mapping);
+    try testing.expect((try b.unwrap()) == i + 1);
+    a.deinit();
+    a = OptionI32.None;
+    var c = try a.map_or(mapping, i);
+    try testing.expect(c == i);
+    var d = OptionI32.None;
+    var e = try d.map_or_else(mapping, defaultF);
+    try testing.expect(e == i);
+}

--- a/src/utils/utils.zig
+++ b/src/utils/utils.zig
@@ -1,0 +1,9 @@
+pub const Iterator = @import("iter.zig").Iterator;
+pub const CompareResult = @import("comparable.zig").CompareResult;
+pub const Comparable = @import("comparable.zig").Comparable;
+pub const isComparableTo = @import("comparable.zig").isComparableTo;
+pub const option = @import("owned_optional_type.zig");
+comptime {
+    _ = option;
+}
+// pub const ComparableManager = @import("comparable.zig").ComparableManager;


### PR DESCRIPTION
which can handle complex things
but still limited
now support only multiple implementations based on subtypes not support type checker on type-erased situations like just to check a type is comparable or not
instead of checking is it compatible to a type
which is not limited by compile time allocations
once when the compile time allocation is done
a full compile time interface implementation and checker will be there

some basic update to match the latest zig

add the optional type from the old project
and make it better by implemented comparable trait for it